### PR TITLE
[INTPROD-1125] Update Runner for GH Action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 on: pull_request
 jobs:
   pre-commit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -14,7 +14,7 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['2.x', '3.x']

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,10 +5,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.6
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.x', '3.x']
+        python-version: ['3.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-deploy-docs:
     name: Build and publish docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -31,7 +31,7 @@ jobs:
           FOLDER: generated/docs # The folder the action should deploy.
   build-and-publish-python-module:
     name: Build and publish python module to pypi
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.6
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install virtualenv
         run: pip install virtualenv
       - name: Build docs
@@ -35,10 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.6
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: '^docs/.*$'
 repos:
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     -   id: flake8


### PR DESCRIPTION
This pull request primarily focuses on updating the GitHub Actions workflows and the pre-commit configuration. The updates include changing the operating system used in the workflows from `ubuntu-18.04` to `ubuntu-latest`, upgrading the Python version from `3.6` to `3.8`, and updating the `flake8` repository and revision in the pre-commit configuration.

GitHub Actions workflows:

* [`.github/workflows/pull_request.yml`](diffhunk://#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cL4-R20): Updated the operating system from `ubuntu-18.04` to `ubuntu-latest` and upgraded the Python version from `3.6` to `3.8`. Also, removed the support for Python 2.x in the test matrix.
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L11-R18): In both the `build-and-deploy-docs` and `build-and-publish-python-module` jobs, updated the operating system from `ubuntu-18.04` to `ubuntu-latest` and upgraded the Python version from `3.6` to `3.8`. [[1]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L11-R18) [[2]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L34-R41)

Pre-commit configuration:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R4): Updated the `flake8` repository from `https://gitlab.com/pycqa/flake8` to `https://github.com/pycqa/flake8` and updated the revision from `3.7.9` to `5.0.4`.