### PR TITLE
[INTPROD-9639] Add reaction payload type support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,10 +5,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.10
+      - name: Setup python 3.10.17
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10
+          python-version: 3.10.17
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10.17']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,10 +5,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.8
+      - name: Setup python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.x']
+        python-version: ['3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.10
+      - name: Setup python 3.10.17
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10
+          python-version: 3.10.17
       - name: Install virtualenv
         run: pip install virtualenv
       - name: Build docs
@@ -35,10 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.10
+      - name: Setup python 3.10.17
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10
+          python-version: 3.10.17
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.8
+      - name: Setup python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install virtualenv
         run: pip install virtualenv
       - name: Build docs
@@ -35,10 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.8
+      - name: Setup python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/omnibot_receiver/router.py
+++ b/omnibot_receiver/router.py
@@ -85,7 +85,8 @@ class OmnibotRouter(object):
                 ]}
         """
         omnibot_payload_type = event.get('omnibot_payload_type')
-        if self.message_router and omnibot_payload_type == 'message' or omnibot_payload_type == 'reaction':
+        if (self.message_router and
+                omnibot_payload_type in {'message', 'reaction'}):
             return self.message_router.handle_message(event)
         elif (self.interactive_router and
               omnibot_payload_type == 'interactive_component'):
@@ -325,7 +326,8 @@ class OmnibotMessageRouter(object):
                     command  -- Match against messages directed at this bot.
                     regex    -- Match against messages in a channel that have
                                 been targeted at this bot by omnibot.
-                    reaction -- Match against reactions towards items made by this bot.
+                    reaction -- Match against reactions towards items
+                                made by this bot.
 
             route_func (function): The function to call when serving this route
             **kwargs (dict): Keyword arguments (see below for more info)

--- a/omnibot_receiver/router.py
+++ b/omnibot_receiver/router.py
@@ -85,7 +85,7 @@ class OmnibotRouter(object):
                 ]}
         """
         omnibot_payload_type = event.get('omnibot_payload_type')
-        if self.message_router and omnibot_payload_type == 'message':
+        if self.message_router and omnibot_payload_type == 'message' or omnibot_payload_type == 'reaction':
             return self.message_router.handle_message(event)
         elif (self.interactive_router and
               omnibot_payload_type == 'interactive_component'):
@@ -258,7 +258,8 @@ class OmnibotMessageRouter(object):
         self.default_route = None
         self.routes = {
             'command': [],
-            'regex': []
+            'regex': [],
+            'reaction': [],
         }
 
     @staticmethod
@@ -321,9 +322,10 @@ class OmnibotMessageRouter(object):
             match_type (str): The type of message this route should match
             against::
 
-                    command -- Match against messages directed at this bot.
-                    regex   -- Match against messages in a channel that have
-                               been targetted at this bot by omnibot.
+                    command  -- Match against messages directed at this bot.
+                    regex    -- Match against messages in a channel that have
+                                been targeted at this bot by omnibot.
+                    reaction -- Match against reactions towards items made by this bot.
 
             route_func (function): The function to call when serving this route
             **kwargs (dict): Keyword arguments (see below for more info)

--- a/tests/unit/omnibot_receiver/router_test.py
+++ b/tests/unit/omnibot_receiver/router_test.py
@@ -244,6 +244,15 @@ class TestOmnibotMessageRouter(object):
         assert message_router.handle_message(message1) == 'a is 1, b is 2'
         assert message_router.handle_message(message2) == 'a is 1, b is 2 to 3'
 
+    def test_reaction_route(self):
+        message = {'args': '+1', 'match_type': 'reaction'}
+        message_router = OmnibotMessageRouter()
+
+        @message_router.route(r'\+1', match_type='reaction')
+        def ping(message):
+            return 'pong'
+
+        assert message_router.handle_message(message) == 'pong'
 
 class TestOmnibotInteractiveRouter(object):
 

--- a/tests/unit/omnibot_receiver/router_test.py
+++ b/tests/unit/omnibot_receiver/router_test.py
@@ -254,6 +254,7 @@ class TestOmnibotMessageRouter(object):
 
         assert message_router.handle_message(message) == 'pong'
 
+
 class TestOmnibotInteractiveRouter(object):
 
     def test_interactive_route(self):


### PR DESCRIPTION
- Modified message_router to support reaction payload types
- Updated python version as 3.8 is no longer supported in the setup environment